### PR TITLE
Fix mandatory value for array $emittedActAs (PHP 8 compatibility)

### DIFF
--- a/lib/Doctrine/Import/Builder.php
+++ b/lib/Doctrine/Import/Builder.php
@@ -923,7 +923,7 @@ class Doctrine_Import_Builder extends Doctrine_Builder
      * @param array  $emittedActAs contains on output an array of actAs command to be appended to output
      * @return string actAs full definition
      */
-    private function innerBuildActAs($actAs, $level = 0, $parent = null, array &$emittedActAs)
+    private function innerBuildActAs($actAs, $level = 0, $parent = null, array &$emittedActAs= array())
     {
         // rewrite special case of actAs: [Behavior] which gave [0] => Behavior
         if (is_array($actAs) && isset($actAs[0]) && !is_array($actAs[0])) {

--- a/lib/Doctrine/Import/Builder.php
+++ b/lib/Doctrine/Import/Builder.php
@@ -923,7 +923,7 @@ class Doctrine_Import_Builder extends Doctrine_Builder
      * @param array  $emittedActAs contains on output an array of actAs command to be appended to output
      * @return string actAs full definition
      */
-    private function innerBuildActAs($actAs, $level = 0, $parent = null, array &$emittedActAs= array())
+    private function innerBuildActAs($actAs, $level = 0, $parent = null, array &$emittedActAs = array())
     {
         // rewrite special case of actAs: [Behavior] which gave [0] => Behavior
         if (is_array($actAs) && isset($actAs[0]) && !is_array($actAs[0])) {


### PR DESCRIPTION
Fix mandatory value for array $emittedActAs (PHP 8 compatibility) https://github.com/FriendsOfSymfony1/doctrine1/pull/82